### PR TITLE
Add ability to set list of roles from client side.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import JoinRoom from "./components/JoinRoom";
 import type { State } from "./types/State";
 import type { Player } from "./types/Player";
 import type { RoomType } from "./types";
+import { Role } from "./types/Player";
 
 // prod server
 const client = new Colyseus.Client("ws://t7y27k.us-east-vin.colyseus.net:2567");
@@ -130,7 +131,20 @@ export default function App() {
 
   const handleNext = () => {
     setButtonClicked(true);
+
+    if (thisRoom?.state.phase === PhaseType.LOBBY) {
+
+      let mafia_count = Math.max(1, Math.floor(thisRoom.state.players.size / 5));
+      // Create the roles array here temporarily. The front end will need a selection menu to select the number of mafia
+      // We are passing an array instead of a number because we will need an array as soon as we introduce roles that aren't mafia.
+      let roles: Array<Role> = Array<Role>(thisRoom.state.players.size);
+      roles.fill(Role.MAFIA, 0, mafia_count);
+      roles.fill(Role.TOWNSPERSON, mafia_count, thisRoom.state.players.size);
+      thisRoom?.send("setRoles", (thisRoom.sessionId, roles));
+    }
+
     thisRoom?.send("nextPhase");
+    
   };
 
   return (


### PR DESCRIPTION
Includes basic logic for now

This message will likely need to be moved but for now it is called on the next phase callback only when in the lobby. I.e. it gets called when starting the game. The logic is that 1 out of every 5 players should be mafia rounded down. so 2-9 players have 1 mafia 10-14 have 2 mafia etc.

This will need to be replaced with a selection menu. For now the menu can just ask the room_owner for a number of mafia, but eventually we will select the entire list from the UI